### PR TITLE
use as_tibble() and skip filter() when not necessary

### DIFF
--- a/R/fitting_fns.R
+++ b/R/fitting_fns.R
@@ -163,11 +163,15 @@ fit_model <- function(data, id_vector, param_names,
         }
     }
 
-    notfitted  <- bind_rows(nofitlist) %>% rbind( bind_rows(noCIlist)) %>% filter(!is.na(index)) %>% arrange(index)
-
+    notfitted  <- bind_rows(nofitlist) %>% rbind( bind_rows(noCIlist))
+    if (nrow(notfitted)) {
+        notfitted <- notfitted %>% filter(!is.na(index)) %>% arrange(index)
+    }
     if(length(notfitted$id) > 0){
         fitted <- bind_rows(fitlist) %>% filter(!id %in% notfitted$id)
-    } else{ fitted <- bind_rows(fitlist) }
+    } else{ 
+        fitted <- bind_rows(fitlist)
+    }
 
     return(list(model_fitlist = model_fitlist, CIlist = CIlist, fitted = fitted, notfitted = notfitted))
 

--- a/R/simulate_data.R
+++ b/R/simulate_data.R
@@ -47,7 +47,7 @@ simulate_data <- function(nsubjects = 10, detection_threshold = 20, censortime =
 
     params <- t(apply(params, 1, switch_simulated_params))
 
-    paramdat <- params %>% tbl_df() %>% mutate(id = ids)
+    paramdat <- params %>% as_tibble() %>% mutate(id = ids)
 
     # 3. Choose number of observations for all subjects
     npoints <- sample(min_datapoints:max_datapoints, replace = TRUE, size = nsubjects)


### PR DESCRIPTION
We see these problems when testing this package against the soon to be released dplyr 1.0.0: 

```
[master*] 133.5 MiB ❯ revdepcheck::revdep_details(revdep = "ushr")
══ Reverse dependency check ══════════════════════════════════════ ushr 0.2.1 ══

Status: BROKEN

── Newly failing

✖ checking examples ... ERROR
✖ checking tests ...

── Before ──────────────────────────────────────────────────────────────────────
0 errors ✔ | 0 warnings ✔ | 0 notes ✔

── After ───────────────────────────────────────────────────────────────────────
❯ checking examples ... ERROR
  Running examples in ‘ushr-Ex.R’ failed
  The error most likely occurred in:

  > ### Name: plot_model
  > ### Title: Plot model fits
  > ### Aliases: plot_model
  >
  > ### ** Examples
  >
  >
  > set.seed(1234567)
  >
  > simulated_data <- simulate_data(nsubjects = 20)
  Joining, by = "id"
  >
  > model_output <- ushr(data = simulated_data)
  Warning in sqrt(diag(fisher_info)) : NaNs produced
  Warning in sqrt(diag(fisher_info)) : NaNs produced
  Warning in sqrt(diag(fisher_info)) : NaNs produced
  Warning in sqrt(diag(fisher_info)) : NaNs produced
  Error: `filter()` argument `..1` errored.
  ℹ `..1` is `!is.na(index)`.
  ✖ object 'index' not found
  Backtrace:
       █
    1. └─ushr::ushr(data = simulated_data)
    2.   └─ushr:::fit_model(...)
    3.     └─`%>%`(...)
    4.       ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
    5.       └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
    6.         └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
    7.           └─ushr:::`_fseq`(`_lhs`)
    8.             └─magrittr::freduce(value, `_function_list`)
    9.               └─function_list[[i]](value)
   10.                 ├─dplyr::filter(., !is.na(index))
   11.                 └─dplyr:::filter.data.frame(., !is.na(index))
   12.                   └─dplyr:::filter_rows(.data, ...)
   13.                     └─base::tryCatch(...)
   14.                       └─base:::tryCatchList(expr, classes, parentenv, handlers)
   15.                         └─base:::tryCatchOne(expr, names, parentenv, h
  Execution halted

❯ checking tests ...
  See below...

── Test failures ───────────────────────────────────────────────── testthat ────

> library(testthat)
> library(ushr)
Loading required package: dplyr

Attaching package: 'dplyr'

The following object is masked from 'package:testthat':

    matches

The following objects are masked from 'package:stats':

    filter, lag

The following objects are masked from 'package:base':

    intersect, setdiff, setequal, union

Loading required package: tidyr

Attaching package: 'tidyr'

The following object is masked from 'package:testthat':

    matches

Loading required package: ggplot2
>
> test_check("ushr")
── 1. Error: test correct input data (@test-filtering.R#18)  ───────────────────
argument of length 0
Backtrace:
  1. testthat::expect_warning(...)
 18. `:`(...)

── 2. Error: test input arguments (@test-fitting.R#8)  ─────────────────────────
`filter()` argument `..1` errored.
ℹ `..1` is `!is.na(index)`.
✖ object 'index' not found
Backtrace:
  1. testthat::expect_warning(...)
  6. ushr::ushr(data = testdata, initial_buffer = 3.5)
  7. ushr:::fit_model(...)
  4. dplyr::bind_rows(nofitlist)
  4. base::rbind(., bind_rows(noCIlist))
 11. dplyr::filter(., !is.na(index))
 17. dplyr:::filter_rows(.data, ...)
 18. base::tryCatch(...)
 19. base:::tryCatchList(expr, classes, parentenv, handlers)
 20. base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
 21. value[[3L]](cond)
 22. dplyr:::stop_eval_tidy(...)
 23. dplyr:::stop_dplyr(index, dots, fn, "errored", x = conditionMessage(e))

══ testthat results  ═══════════════════════════════════════════════════════════
[ OK: 11 | SKIPPED: 0 | WARNINGS: 1 | FAILED: 2 ]
1. Error: test correct input data (@test-filtering.R#18)
2. Error: test input arguments (@test-fitting.R#8)

Error: testthat unit tests failed
Execution halted

2 errors ✖ | 0 warnings ✔ | 0 notes ✔
```

This pull request adresses part of the problems, this one remains to be fixed: 

```
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
test-filtering.R:18: error: test correct input data
argument of length 0
Backtrace:
  1. testthat::expect_warning(...) tests/testthat/test-filtering.R:18:4
 18. `:`(...)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```